### PR TITLE
fix: validate input in integer-coding classes

### DIFF
--- a/src/komm/_integer_coding/FibonacciCode.py
+++ b/src/komm/_integer_coding/FibonacciCode.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .. import abc
+from .._util.validators import validate_integer_min, validate_integer_range
 
 
 class FibonacciCode(abc.IntegerCode):
@@ -13,12 +14,14 @@ class FibonacciCode(abc.IntegerCode):
 
     def encode(self, input: npt.ArrayLike) -> npt.NDArray[np.integer]:
         r"""
+        Encode the input integer array. The integers must be positive.
+
         Examples:
             >>> code = komm.FibonacciCode()
             >>> code.encode([4, 1, 3])
             array([1, 0, 1, 1, 1, 1, 0, 0, 1, 1])
         """
-        input = np.asarray(input)
+        input = validate_integer_min(input, low=1)
         if input.size == 0:
             return np.array([], dtype=int)
         return np.concatenate([fibonacci_encode(i) for i in input])
@@ -30,13 +33,15 @@ class FibonacciCode(abc.IntegerCode):
             >>> code.decode([1, 0, 1, 1, 1, 1, 0, 0, 1, 1])
             array([4, 1, 3])
         """
-        input = np.asarray(input)
+        input = validate_integer_range(input, low=0, high=2)
         output: list[int] = []
         i = 0
         while i < input.size:
             j = i
-            while not input[j] == input[j + 1] == 1:
+            while j + 1 < input.size and not input[j] == input[j + 1] == 1:
                 j += 1
+            if j + 1 >= input.size:
+                raise ValueError("input contains an incomplete codeword")
             output.append(fibonacci_decode(list(input[i : j + 2])))
             i = j + 2
         return np.array(output)

--- a/src/komm/_integer_coding/UnaryCode.py
+++ b/src/komm/_integer_coding/UnaryCode.py
@@ -2,6 +2,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .. import abc
+from .._util.validators import validate_integer_min, validate_integer_range
 
 
 class UnaryCode(abc.IntegerCode):
@@ -11,12 +12,14 @@ class UnaryCode(abc.IntegerCode):
 
     def encode(self, input: npt.ArrayLike) -> npt.NDArray[np.integer]:
         r"""
+        Encode the input integer array. The integers must be non-negative.
+
         Examples:
             >>> code = komm.UnaryCode()
             >>> code.encode([4, 1, 3])
             array([1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 0])
         """
-        input = np.asarray(input)
+        input = validate_integer_min(input, low=0)
         if input.size == 0:
             return np.array([], dtype=int)
         return np.concatenate([unary_encode(i) for i in input])
@@ -28,13 +31,15 @@ class UnaryCode(abc.IntegerCode):
             >>> code.decode([1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 0])
             array([4, 1, 3])
         """
-        input = np.asarray(input)
+        input = validate_integer_range(input, low=0, high=2)
         output: list[int] = []
         i = 0
         while i < input.size:
             j = i
-            while input[j] == 1:
+            while j < input.size and input[j] == 1:
                 j += 1
+            if j == input.size:
+                raise ValueError("input contains an incomplete codeword")
             output.append(unary_decode(list(input[i : j + 1])))
             i = j + 1
         return np.array(output)

--- a/src/komm/_util/validators.py
+++ b/src/komm/_util/validators.py
@@ -70,3 +70,14 @@ def validate_integer_range(
     if not (np.all(value >= low) and np.all(value < high)):
         raise ValueError(f"input contains invalid entries (expected in [{low}:{high}))")
     return value
+
+
+def validate_integer_min(
+    value: npt.ArrayLike,
+    *,
+    low: int = 0,
+) -> npt.NDArray[np.integer]:
+    value = np.asarray(value, dtype=int)
+    if not np.all(value >= low):
+        raise ValueError(f"input contains invalid entries (expected at least {low})")
+    return value

--- a/tests/integer_coding/test_validation.py
+++ b/tests/integer_coding/test_validation.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+import komm
+
+
+def test_unary_encode_rejects_negative():
+    code = komm.UnaryCode()
+    for message in ([-1], [-3], [0, 1, -2]):
+        with pytest.raises(ValueError, match="invalid entries"):
+            code.encode(message)
+
+
+def test_unary_encode_accepts_zero():
+    code = komm.UnaryCode()
+    np.testing.assert_equal(code.encode([0]), [0])
+
+
+def test_fibonacci_encode_rejects_nonpositive():
+    code = komm.FibonacciCode()
+    for message in ([0], [-1], [1, 0, 2]):
+        with pytest.raises(ValueError, match="invalid entries"):
+            code.encode(message)
+
+
+@pytest.mark.parametrize(
+    "code, stream",
+    [
+        (komm.UnaryCode(), [1, 1, 1]),
+        (komm.FibonacciCode(), [1, 0, 1, 0]),
+        (komm.FibonacciCode(), [0, 0, 0]),
+    ],
+)
+def test_decode_rejects_incomplete_codeword(code, stream):
+    with pytest.raises(ValueError, match="incomplete codeword"):
+        code.decode(stream)
+
+
+@pytest.mark.parametrize(
+    "code, stream",
+    [
+        (komm.UnaryCode(), [1, 2, 0]),
+        (komm.UnaryCode(), [0, 5]),
+        (komm.FibonacciCode(), [1, 1, 2]),
+    ],
+)
+def test_decode_rejects_non_binary_bits(code, stream):
+    with pytest.raises(ValueError, match="invalid entries"):
+        code.decode(stream)
+
+
+def test_valid_roundtrips_unaffected():
+    unary = komm.UnaryCode()
+    message = list(range(0, 50))  # Unary domain: non-negative integers.
+    np.testing.assert_equal(unary.decode(unary.encode(message)), message)
+    fibonacci = komm.FibonacciCode()
+    message = list(range(1, 50))  # Fibonacci domain: positive integers.
+    np.testing.assert_equal(fibonacci.decode(fibonacci.encode(message)), message)


### PR DESCRIPTION
Unlike the lossless-coding classes (which gained input validation in v0.26.2), `UnaryCode` and `FibonacciCode` validate neither the integers passed to `encode` nor the bits passed to `decode`. This causes a few related problems:

- `FibonacciCode.encode([0])` (or any non-positive integer) raises `ValueError: max() arg is an empty sequence`, leaking an internal detail instead of a clear domain error. Fibonacci/Zeckendorf coding is only defined for positive integers.
- `UnaryCode.encode([-1])` returns `[0]` with no error, silently corrupting the data — `decode(encode([-1]))` gives `0`, not `-1`.
- The two codes disagree on their domain and neither documents it: `UnaryCode.encode([0])` returns `[0]`, but `FibonacciCode.encode([0])` crashes.
- Both decoders raise `IndexError` on a truncated or non-binary stream, e.g. `UnaryCode.decode([1, 1, 1])`, `FibonacciCode.decode([1, 0, 1, 0])`, `FibonacciCode.decode([0, 0, 0])`.

This adds validation in the same style as the `validate_integer_range` helper the lossless codes already use:

- `encode` checks the integer domain (unary is defined for non-negative integers, Fibonacci for positive integers) and documents it. The domains match what the existing tests already exercise — `test_unary_code` encodes `0`, and the shared round-trip tests only use positive integers.
- `decode` checks the bit alphabet `{0, 1}` and that each codeword is terminated, raising a clear `ValueError` instead of an `IndexError`.

Valid round-trips are unchanged. Added `tests/integer_coding/test_validation.py` covering the rejected cases and asserting valid round-trips still pass.
